### PR TITLE
add a configuration option for 'qualifier'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Output plugin for [AWS Lambda](http://aws.amazon.com/lambda/).
   region us-east-1
   #endpoint ...
 
+  #qualifier staging
   function_name my_func
   # Pass the function name in the key of record if the function name is not set
 

--- a/lib/fluent/plugin/out_lambda.rb
+++ b/lib/fluent/plugin/out_lambda.rb
@@ -15,6 +15,7 @@ class Fluent::LambdaOutput < Fluent::BufferedOutput
   config_param :region,                     :string, :default => nil
   config_param :endpoint,                   :string, :default => nil
   config_param :function_name,              :string, :default => nil
+  config_param :qualifier,                  :string, :default => nil
 
   config_set_default :include_time_key, false
   config_set_default :include_tag_key,  false
@@ -68,11 +69,14 @@ class Fluent::LambdaOutput < Fluent::BufferedOutput
     }.each {|tag, time, record|
       func_name = @function_name || record['function_name']
 
-      @client.invoke(
+      payload = {
         :function_name => func_name,
         :payload => JSON.dump(record),
         :invocation_type => 'Event',
-      )
+      }
+      payload[:qualifier] = @qualifier unless @qualifier.nil?
+
+      @client.invoke(payload)
     }
   end
 

--- a/spec/out_lambda_spec.rb
+++ b/spec/out_lambda_spec.rb
@@ -60,4 +60,27 @@ describe Fluent::LambdaOutput do
       end
     end
   end
+
+  context 'when a qualifier is provided' do
+    it 'invokes that alias' do
+      run_driver(qualifier: 'staging') do |d, client|
+        expect(client).to receive(:invoke).with(
+          function_name: 'my_func1',
+          payload: JSON.dump('function_name' => 'my_func1', 'key1' => 'foo' , 'key2' => 100),
+          invocation_type: 'Event',
+          qualifier: 'staging'
+        )
+
+        expect(client).to receive(:invoke).with(
+          function_name: 'my_func2',
+          payload: JSON.dump('function_name' => 'my_func2', 'key1' => 'bar' , 'key2' => 200),
+          invocation_type: 'Event',
+          qualifier: 'staging'
+        )
+
+        d.emit({'function_name' => 'my_func1', 'key1' => 'foo', 'key2' => 100}, time)
+        d.emit({'function_name' => 'my_func2', 'key1' => 'bar', 'key2' => 200}, time)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Version aliases are pretty darn useful for lambda, it'd be really nice to be able to specify them via configuration.
http://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html
