### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: ruby
 rvm:
-- 2.0.0
+- 2.1
+- 2.2
+- 2.3.4
+- 2.4.1
+before_install:
+- gem update bundler
 script:
 - bundle install
 - bundle exec rake

--- a/fluent-plugin-lambda.gemspec
+++ b/fluent-plugin-lambda.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.0.0'
+  spec.add_development_dependency 'test-unit', '>= 3.2.0'
 end

--- a/lib/fluent/plugin/out_lambda.rb
+++ b/lib/fluent/plugin/out_lambda.rb
@@ -1,3 +1,5 @@
+require 'json'
+require 'aws-sdk-core'
 require 'fluent/plugin/output'
 
 class Fluent::Plugin::LambdaOutput < Fluent::Plugin::Output
@@ -33,8 +35,6 @@ class Fluent::Plugin::LambdaOutput < Fluent::Plugin::Output
 
   def initialize
     super
-    require 'aws-sdk-core'
-    require 'json'
   end
 
   def configure(conf)

--- a/lib/fluent/plugin/out_lambda.rb
+++ b/lib/fluent/plugin/out_lambda.rb
@@ -9,13 +9,6 @@ class Fluent::Plugin::LambdaOutput < Fluent::Plugin::Output
 
   DEFAULT_BUFFER_TYPE = "memory"
 
-  include Fluent::SetTimeKeyMixin
-  include Fluent::SetTagKeyMixin
-
-  unless method_defined?(:log)
-    define_method('log') { $log }
-  end
-
   config_param :profile,                    :string, :default => nil
   config_param :credentials_path,           :string, :default => nil
   config_param :aws_key_id,                 :string, :default => nil

--- a/lib/fluent/plugin/out_lambda.rb
+++ b/lib/fluent/plugin/out_lambda.rb
@@ -5,7 +5,7 @@ require 'fluent/plugin/output'
 class Fluent::Plugin::LambdaOutput < Fluent::Plugin::Output
   Fluent::Plugin.register_output('lambda', self)
 
-  helpers :compat_parameters
+  helpers :compat_parameters, :inject
 
   DEFAULT_BUFFER_TYPE = "memory"
 
@@ -38,7 +38,7 @@ class Fluent::Plugin::LambdaOutput < Fluent::Plugin::Output
   end
 
   def configure(conf)
-    compat_parameters_convert(conf, :buffer)
+    compat_parameters_convert(conf, :buffer, :inject)
     super
 
     aws_opts = {}
@@ -83,6 +83,7 @@ class Fluent::Plugin::LambdaOutput < Fluent::Plugin::Output
         false
       end
     }.each {|tag, time, record|
+      record = inject_values_to_record(tag, time, record)
       func_name = @function_name || record['function_name']
 
       payload = {

--- a/spec/out_lambda_spec.rb
+++ b/spec/out_lambda_spec.rb
@@ -1,6 +1,8 @@
-describe Fluent::LambdaOutput do
+describe Fluent::Plugin::LambdaOutput do
+  include Fluent::Test::Helpers
+
   let(:time) {
-    Time.parse('2014-09-01 01:23:45 UTC').to_i
+    event_time('2014-09-01 01:23:45 UTC')
   }
 
   context 'when events is sent' do
@@ -18,8 +20,8 @@ describe Fluent::LambdaOutput do
           invocation_type: 'Event',
         )
 
-        d.emit({'key1' => 'foo', 'key2' => 100}, time)
-        d.emit({'key1' => 'bar', 'key2' => 200}, time)
+        d.feed(time, {'key1' => 'foo', 'key2' => 100})
+        d.feed(time, {'key1' => 'bar', 'key2' => 200})
       end
     end
   end
@@ -39,8 +41,8 @@ describe Fluent::LambdaOutput do
           invocation_type: 'Event',
         )
 
-        d.emit({'function_name' => 'my_func1', 'key1' => 'foo', 'key2' => 100}, time)
-        d.emit({'function_name' => 'my_func2', 'key1' => 'bar', 'key2' => 200}, time)
+        d.feed(time, {'function_name' => 'my_func1', 'key1' => 'foo', 'key2' => 100})
+        d.feed(time, {'function_name' => 'my_func2', 'key1' => 'bar', 'key2' => 200})
       end
     end
   end
@@ -50,8 +52,8 @@ describe Fluent::LambdaOutput do
       run_driver do |d, client|
         expect(client).to_not receive(:invoke)
 
-        d.emit({'key1' => 'foo', 'key2' => 100}, time)
-        d.emit({'key1' => 'bar', 'key2' => 200}, time)
+        d.feed(time, {'key1' => 'foo', 'key2' => 100})
+        d.feed(time, {'key1' => 'bar', 'key2' => 200})
 
         expect(d.instance.log).to receive(:warn).
            with('`function_name` key does not exist: ["test.default", 1409534625, {"key1"=>"foo", "key2"=>100}]')
@@ -78,8 +80,8 @@ describe Fluent::LambdaOutput do
           qualifier: 'staging'
         )
 
-        d.emit({'function_name' => 'my_func1', 'key1' => 'foo', 'key2' => 100}, time)
-        d.emit({'function_name' => 'my_func2', 'key1' => 'bar', 'key2' => 200}, time)
+        d.feed(time, {'function_name' => 'my_func1', 'key1' => 'foo', 'key2' => 100})
+        d.feed(time, {'function_name' => 'my_func2', 'key1' => 'bar', 'key2' => 200})
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'fluent/test'
+require 'fluent/test/driver/output'
+require 'fluent/test/helpers'
 require 'fluent/plugin/out_lambda'
 require 'aws-sdk-core'
 require 'time'
@@ -27,9 +29,9 @@ region us-west-1
 #{additional_options}
   EOS
 
-  driver = Fluent::Test::OutputTestDriver.new(Fluent::LambdaOutput, tag).configure(fluentd_conf)
+  driver = Fluent::Test::Driver::Output.new(Fluent::Plugin::LambdaOutput).configure(fluentd_conf)
 
-  driver.run do
+  driver.run(default_tag: tag) do
     client = driver.instance.instance_variable_get(:@client)
     yield(driver, client)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ require 'time'
 
 # Disable Test::Unit
 module Test::Unit::RunCount; def run(*); end; end
+# prevent Test::Unit's AutoRunner from executing during RSpec's rake task
+Test::Unit.run = true if defined?(Test::Unit) && Test::Unit.respond_to?(:run=)
 
 RSpec.configure do |config|
   config.before(:all) do


### PR DESCRIPTION
I've tried to use v0.14 Output plugin API.
This PR contains major update change.
Could you bump up minor version if releasing new version of gem?

Thanks,