### PR TITLE
Remove needless default buffer chunk_keys

### DIFF
--- a/lib/fluent/plugin/out_lambda.rb
+++ b/lib/fluent/plugin/out_lambda.rb
@@ -23,7 +23,6 @@ class Fluent::Plugin::LambdaOutput < Fluent::Plugin::Output
 
   config_section :buffer do
     config_set_default :@type, DEFAULT_BUFFER_TYPE
-    config_set_default :chunk_keys, ['tag']
   end
 
   def initialize


### PR DESCRIPTION
With this PR, users will be able to choose just buffered plugin[1] or tag separated chunk buffered plugin[2] or time sliced buffed output plugin[3].

[1]
```aconf
<match **>
  @type lambda
   <buffer>
      @type memory
   </buffer>
   # <snip>
</match>
```

[2]
```aconf
<match **>
  @type lambda
   <buffer tag>
      @type memory
   </buffer>
   # <snip>
</match>
```

[3]
```aconf
<match **>
  @type lambda
   <buffer tag, time>
      @type memory
      timekey 3600 # for 1 hour
   </buffer>
   # <snip>
</match>
```