### PR TITLE
Use aws-sdk v3 service specific gem

### DIFF
--- a/fluent-plugin-lambda.gemspec
+++ b/fluent-plugin-lambda.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'fluentd'
-  spec.add_dependency 'aws-sdk-core', '~> 2.1'
+  spec.add_dependency 'aws-sdk-lambda', '~> 1.0'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.0.0'

--- a/lib/fluent/plugin/out_lambda.rb
+++ b/lib/fluent/plugin/out_lambda.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'aws-sdk-core'
+require 'aws-sdk-lambda'
 require 'fluent/plugin/output'
 
 class Fluent::Plugin::LambdaOutput < Fluent::Plugin::Output


### PR DESCRIPTION
aws-sdk-v3 and service specific gems are released.

For Lambda:
https://rubygems.org/gems/aws-sdk-lambda

Then, we can migrate to use aws-sdk v3 dynamodb specific gem.

ref: https://aws.amazon.com/jp/blogs/developer/upgrading-from-version-2-to-version-3-of-the-aws-sdk-for-ruby-2/